### PR TITLE
get column width on windows

### DIFF
--- a/textcol.go
+++ b/textcol.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"math"
 	"os"
-	"os/exec"
-	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -73,17 +71,6 @@ func PrintColumns(strs *[]string, margin int) {
 			fmt.Fprintf(Output, marginStr)
 		}
 	}
-}
-
-func getTermWidth() int {
-	cmd := exec.Command("stty", "size")
-	cmd.Stdin = os.Stdin
-	out, err1 := cmd.Output()
-	check(err1)
-	numsStr := strings.Trim(string(out), "\n ")
-	width, err2 := strconv.Atoi(strings.Split(numsStr, " ")[1])
-	check(err2)
-	return width
 }
 
 func calculateTableSize(width, margin, maxLength, numCells int) (int, int) {

--- a/textcol_other.go
+++ b/textcol_other.go
@@ -1,0 +1,21 @@
+// +build !windows
+
+package textcol
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func getTermWidth() int {
+	cmd := exec.Command("stty", "size")
+	cmd.Stdin = os.Stdin
+	out, err1 := cmd.Output()
+	check(err1)
+	numsStr := strings.Trim(string(out), "\n ")
+	width, err2 := strconv.Atoi(strings.Split(numsStr, " ")[1])
+	check(err2)
+	return width
+}

--- a/textcol_win.go
+++ b/textcol_win.go
@@ -1,0 +1,57 @@
+// +build windows
+
+package textcol
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+	// GetConsoleScreenBufferInfo retrieves information about the
+	// specified console screen buffer.
+	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms683171(v=vs.85).aspx
+	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+)
+
+type (
+	// Defines the coordinates of the upper left and lower right corners
+	// of a rectangle.
+	// See
+	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms686311(v=vs.85).aspx
+	smallRect struct {
+		Left, Top, Right, Bottom int16
+	}
+
+	// Defines the coordinates of a character cell in a console screen
+	// buffer. The origin of the coordinate system (0,0) is at the top, left cell
+	// of the buffer.
+	// See
+	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms682119(v=vs.85).aspx
+	coordinates struct {
+		X, Y int16
+	}
+
+	word int16
+
+	// Contains information about a console screen buffer.
+	// http://msdn.microsoft.com/en-us/library/windows/desktop/ms682093(v=vs.85).aspx
+	consoleScreenBufferInfo struct {
+		dwSize              coordinates
+		dwCursorPosition    coordinates
+		wAttributes         word
+		srWindow            smallRect
+		dwMaximumWindowSize coordinates
+	}
+)
+
+func getTermWidth() int {
+	var info consoleScreenBufferInfo
+	_, _, e := syscall.Syscall(procGetConsoleScreenBufferInfo.Addr(), 2, uintptr(syscall.Stdout), uintptr(unsafe.Pointer(&info)), 0)
+	if e != 0 {
+		check(error(e))
+	}
+	return int(info.dwSize.X) - 1
+}


### PR DESCRIPTION
I don't have stty executable on windows, so I changed it to use system call interface on windows.